### PR TITLE
CGV-2655/add-http-methods

### DIFF
--- a/Sources/NWHttpConnection/CompositionRoot/NWHttpConnectionFactory.swift
+++ b/Sources/NWHttpConnection/CompositionRoot/NWHttpConnectionFactory.swift
@@ -13,6 +13,7 @@ public class NWHttpConnectionFactory {
         return NWHttpConnection(url: configuration.url,
                                 method: configuration.method,
                                 headers: configuration.headers,
+                                body: configuration.body,
                                 certificateValidation: configuration.certificateValidation,
                                 dataResponseType: configuration.dataResponseType,
                                 nwConnectionProvider: Self.makeNWConnectionProvider())

--- a/Sources/NWHttpConnection/Domain/Entities/NWConnectionConfiguration.swift
+++ b/Sources/NWHttpConnection/Domain/Entities/NWConnectionConfiguration.swift
@@ -8,22 +8,24 @@
 import Foundation
 
 public struct NWConnectionConfiguration {
-
     let url: URL
     let method: NWConnectionHTTPMethod
     let headers: [String: String]?
+    let body: Data?
     let certificateValidation: CertificateValidation
     let dataResponseType: NWDataResponseType
     var timeout: TimeInterval = 30
     var queue: DispatchQueue? = nil
     
-    public init(url: URL, method: NWConnectionHTTPMethod, headers: [String: String]? = nil, certificateValidation: CertificateValidation, dataResponseType: NWDataResponseType, timeout: TimeInterval = 30, queue: DispatchQueue? = nil) {
+    public init(url: URL, method: NWConnectionHTTPMethod, headers: [String: String]? = nil, body: Data?, certificateValidation: CertificateValidation, dataResponseType: NWDataResponseType, timeout: TimeInterval = 30, queue: DispatchQueue? = nil) {
         self.url = url
         self.method = method
         self.headers = headers
+        self.body = body
         self.certificateValidation = certificateValidation
         self.dataResponseType = dataResponseType
         self.timeout = timeout
         self.queue = queue
     }
+    
 }

--- a/Sources/NWHttpConnection/Domain/Entities/NWConnectionHTTPMethod.swift
+++ b/Sources/NWHttpConnection/Domain/Entities/NWConnectionHTTPMethod.swift
@@ -8,4 +8,7 @@ import Foundation
 
 public enum NWConnectionHTTPMethod: String {
     case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
 }

--- a/Tests/NWHttpConnectionTests/NWHttpConnectionTests.swift
+++ b/Tests/NWHttpConnectionTests/NWHttpConnectionTests.swift
@@ -8,6 +8,7 @@ class NWHttpConnectionTests: XCTestCase {
     class Fixture {
         var url: URL = URL(string: "https://123.334.987/api")!
         var method: NWConnectionHTTPMethod = .get
+        var body: Data?
         var certificateValidationMock = CertificateValidationMock()
         var nwConnectionProviderMock: NWConnectionProviderMock!
         var nwConnectionTypeMock: NWConnectionTypeMock!
@@ -48,7 +49,7 @@ class NWHttpConnectionTests: XCTestCase {
     }
     
     private func instantiateSut(with timeout: TimeInterval = 60) {
-        sut = NWHttpConnection(url: fixture.url, method: fixture.method, certificateValidation: fixture.certificateValidationMock, dataResponseType: fixture.dataResponseType, nwConnectionProvider: fixture.nwConnectionProviderMock, timeout: timeout)
+        sut = NWHttpConnection(url: fixture.url, method: fixture.method, body: fixture.body, certificateValidation: fixture.certificateValidationMock, dataResponseType: fixture.dataResponseType, nwConnectionProvider: fixture.nwConnectionProviderMock, timeout: timeout)
     }
     
     func test_startConnectionWhenStateIsReady() throws {


### PR DESCRIPTION
Code updated to work with PUT, POST, and DELETE HTTP Methods


- "Content-Length" parameter is added to the HEADERS only if the body contains data.
- Streamlined connection creation to a single sendConnectionRequest method. If the body contains data, it's included as JSON in the content.
- Updated tests, only added a new Data variable to the Fixture.