### PR TITLE
CGV-2735/remove-waiting-propagation

### DIFF
--- a/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
+++ b/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
@@ -224,7 +224,7 @@ internal extension NWHttpConnection {
         case .setup:
             break
         case .waiting(let error):
-            handle?(.wait(error), nil)
+            guard case .posix(let posixError) = error, posixError == .ENETDOWN  else { return }
             connection.cancel()
         default:
             break


### PR DESCRIPTION
Testing a client without connection triggers the `.waiting` state from the library, this state is triggered 2 times when trying to establish a connection without internet, and this ends up propagating the error to the client, causing the client to receive 2 responses from the request before the request being canceled.

One option to avoid this behavior is to remove `.waiting` state handling and cancel the connection when a "no viable network" error is received, this will immediately send the canceled connection error to the client. 

ℹ️ This is an open discussion. Understand what are the other cases where the library could enter in the `.waiting` state.