### PR TITLE
CGV-2733/convert-content-to-data-with-utf8

### DIFF
--- a/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
+++ b/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
@@ -144,7 +144,7 @@ internal extension NWHttpConnection {
         }
         
         connection.send(
-            content: content.data(using: .ascii),
+            content: content.data(using: .utf8),
             contentContext: .defaultMessage,
             isComplete: true,
             completion: NWConnection.SendCompletion.contentProcessed(


### PR DESCRIPTION
Changed content data encoding to UTF-8
The ASCII encoding was found to be incompatible with some JSON. However, the use of UTF-8 resulted in the successful completion of all requests.