### PR TITLE
PIA-1840: Handle response data inside custom type and include status

### DIFF
--- a/Sources/NWHttpConnection/Domain/Entities/Foundation+Extensions.swift
+++ b/Sources/NWHttpConnection/Domain/Entities/Foundation+Extensions.swift
@@ -1,0 +1,11 @@
+
+import Foundation
+
+public extension Array {
+    subscript(safeAt index: Int) -> Element? {
+        if index >= count || index < 0 {
+            return nil
+        }
+        return self[index]
+    }
+}

--- a/Sources/NWHttpConnection/Domain/Entities/NWHttpConnectionDataResponse.swift
+++ b/Sources/NWHttpConnection/Domain/Entities/NWHttpConnectionDataResponse.swift
@@ -1,0 +1,8 @@
+
+import Foundation
+
+public struct NWHttpConnectionDataResponse {
+    public let statusCode: Int?
+    public let dataFormat: NWDataResponseType
+    public let data: Data?
+}

--- a/Tests/NWHttpConnectionTests/NWHttpConnectionTests.swift
+++ b/Tests/NWHttpConnectionTests/NWHttpConnectionTests.swift
@@ -13,7 +13,7 @@ class NWHttpConnectionTests: XCTestCase {
         var nwConnectionProviderMock: NWConnectionProviderMock!
         var nwConnectionTypeMock: NWConnectionTypeMock!
         var dataResponseType: NWDataResponseType = .jsonData
-        var receivedData: Data?
+        var receivedData: NWHttpConnectionDataResponse?
         var receivedError: NWHttpConnectionError?
         var requestHandler: NWHttpConnection.RequestHandler?
         var requestCompletionCalled = false


### PR DESCRIPTION
- In order to have a more detailed response and not having to parse the data multiple times, this PR returns a custom struct instead of a `Data` object that contains: statusCode, data response, the format of the data response.
We still can choose to get the data as a `JSON` data object or the raw data returned from the server. 
