### PR TITLE
PIA-1840: Fix json parsing data

### DIFF
--- a/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
+++ b/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
@@ -176,7 +176,7 @@ internal extension NWHttpConnection {
         
         let jsonStringComponents = utfDataString.split(separator: "\r\n")
         let jsonString = jsonStringComponents.filter {
-            $0.starts(with: "{\"") && $0.contains("}")
+            $0.starts(with: "{") && $0.contains("}")
         }.first
         
         guard let jsonString else { return nil }


### PR DESCRIPTION
Some Json response don't have an `"` immediately after the `{` 
This PR is to be able to parse any object defined between curly braces and return it as the json object data.