### PR TITLE
PIA-1840: Pass timeout configuration option to nwconnection

### DIFF
--- a/Sources/NWHttpConnection/CompositionRoot/NWHttpConnectionFactory.swift
+++ b/Sources/NWHttpConnection/CompositionRoot/NWHttpConnectionFactory.swift
@@ -16,7 +16,9 @@ public class NWHttpConnectionFactory {
                                 body: configuration.body,
                                 certificateValidation: configuration.certificateValidation,
                                 dataResponseType: configuration.dataResponseType,
-                                nwConnectionProvider: Self.makeNWConnectionProvider())
+                                nwConnectionProvider: Self.makeNWConnectionProvider(),
+                                timeout: configuration.timeout,
+                                queue: configuration.queue)
     }
     
 }

--- a/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
+++ b/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
@@ -220,9 +220,7 @@ internal extension NWHttpConnection {
     private func processCompleted(with data: Data?, connection: NWConnectionType, handle: RequestHandler?) {
         if let data {
             let responseData = makeNWHttpConnectionDataResponse(from: data)
-            DispatchQueue.main.async {
-                handle?(nil, responseData)
-            }
+            handle?(nil, responseData)
         }
         
         connection.cancel()


### PR DESCRIPTION
The timeout attribute passed in the NWConnectionConfiguration was not taking effect on the network because the Factory object was not passing it to the `NWHttpConnection` object. 
This PR fixes that by:
- Pass all the attributes from the connection configuration to the NWHttpConnection object

This PR also removes the execution of the request handler on the main queue. This adds flexibility to the clients to execute that block on the queue they want.