### PR TITLE
PIA-1840: Add public interface in front of the data response API

### DIFF
--- a/Sources/NWHttpConnection/Domain/Entities/NWHttpConnectionDataResponse.swift
+++ b/Sources/NWHttpConnection/Domain/Entities/NWHttpConnectionDataResponse.swift
@@ -1,7 +1,13 @@
 
 import Foundation
 
-public struct NWHttpConnectionDataResponse {
+public protocol NWHttpConnectionDataResponseType {
+    var statusCode: Int? { get }
+    var dataFormat: NWDataResponseType { get }
+    var data: Data? { get }
+}
+
+public struct NWHttpConnectionDataResponse: NWHttpConnectionDataResponseType {
     public let statusCode: Int?
     public let dataFormat: NWDataResponseType
     public let data: Data?

--- a/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
+++ b/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
@@ -11,7 +11,7 @@ import Network
 import CommonCrypto
 
 public protocol NWHttpConnectionType {
-    typealias RequestHandler = (NWHttpConnectionError?, NWHttpConnectionDataResponse?) -> Void
+    typealias RequestHandler = (NWHttpConnectionError?, NWHttpConnectionDataResponseType?) -> Void
     typealias Completion = () -> Void
     
     func connect(requestHandler: NWHttpConnectionType.RequestHandler?, completion: NWHttpConnectionType.Completion?) throws

--- a/Tests/NWHttpConnectionTests/NWHttpConnectionTests.swift
+++ b/Tests/NWHttpConnectionTests/NWHttpConnectionTests.swift
@@ -13,7 +13,7 @@ class NWHttpConnectionTests: XCTestCase {
         var nwConnectionProviderMock: NWConnectionProviderMock!
         var nwConnectionTypeMock: NWConnectionTypeMock!
         var dataResponseType: NWDataResponseType = .jsonData
-        var receivedData: NWHttpConnectionDataResponse?
+        var receivedData: NWHttpConnectionDataResponseType?
         var receivedError: NWHttpConnectionError?
         var requestHandler: NWHttpConnection.RequestHandler?
         var requestCompletionCalled = false


### PR DESCRIPTION
Create a public protocol to represent the `NWHttpConnectionDataResponse` that the connection returns, so it is easier to generate mock objects from other clients to stub different states of the `NWHttpConnectionDataResponse`