### PR TITLE
KM-14792: Allow NWConnection to self-recover from transient ENETDOWN on cellular

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "NWHttpConnection",
     platforms: [
         .tvOS(.v17),
-        .iOS(.v12)
+        .iOS(.v15)
     ],
     products: [
         .library(
@@ -16,8 +16,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "NWHttpConnection",
-            resources: [.process("Resources/")]
+            name: "NWHttpConnection"
         ),
         .testTarget(
             name: "NWHttpConnectionTests",

--- a/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
+++ b/Sources/NWHttpConnection/Domain/NWHttpConnection.swift
@@ -245,9 +245,12 @@ internal extension NWHttpConnection {
             sendConnectionRequest(connection: connection, handle: handle)
         case .setup:
             break
-        case .waiting(let error):
-            guard case .posix(let posixError) = error, posixError == .ENETDOWN  else { return }
-            connection.cancel()
+        case .waiting:
+            // Let NWConnection wait for the network to become available.
+            // ENETDOWN is transient on cellular (radio wake-up) and NWConnection
+            // will automatically proceed once the path is ready. The deadline timer
+            // already provides a hard timeout to prevent waiting indefinitely.
+            break
         default:
             break
         }

--- a/Tests/NWHttpConnectionTests/NWHttpConnectionTests.swift
+++ b/Tests/NWHttpConnectionTests/NWHttpConnectionTests.swift
@@ -155,14 +155,15 @@ class NWHttpConnectionTests: XCTestCase {
         XCTAssertTrue(fixture.nwConnectionTypeMock.receiveCalled)
         
         // AND WHEN the NWConnection state is 'waiting'
-        // AND WHEN there is not a viable network
+        // AND WHEN there is not a viable network (e.g. ENETDOWN during cellular radio wake-up)
         fixture.nwConnectionTypeMock.stateUpdateHandler?(NWConnection.State.waiting(NWError.posix(.ENETDOWN)))
         
         // AND the content remains NOT sent
         XCTAssertFalse(fixture.nwConnectionTypeMock.sendCalled)
         
-        // THEN the connection gets cancelled
-        XCTAssertTrue(fixture.nwConnectionTypeMock.cancelCalled)
+        // THEN the connection is NOT cancelled — NWConnection self-recovers once the path is ready.
+        // The deadline timer provides the hard timeout if the network never becomes available.
+        XCTAssertFalse(fixture.nwConnectionTypeMock.cancelCalled)
     }
     
     func test_startConnectionWhenStateIsFailed() throws {


### PR DESCRIPTION
## Summary

- Removes the logic that cancelled `NWConnection` when entering the `.waiting` state with an `ENETDOWN` error
- On cellular, `ENETDOWN` is a transient condition caused by radio wake-up; cancelling the connection prevented it from ever recovering
- `NWConnection` will now wait and automatically proceed once the network path is ready; the existing deadline timer already enforces a hard timeout